### PR TITLE
Filter

### DIFF
--- a/slurm_gres_viz/args.py
+++ b/slurm_gres_viz/args.py
@@ -24,7 +24,7 @@ parser.add_argument('-gm', '--gpu-memory', action='store_true',
 parser.add_argument('-gu', '--gpu-util', action='store_true',
                     help='asd')
 
-parser.add_argument('-p', '--filter', type=str, default='', help='give a filter string. e.g. "job_name=foo" "n=foo" "job_id={1,2-4}" "id={1,2-4}" "user_id=bar" "uid=bar" "node=foo-1" "w=foo-1"')
+parser.add_argument('-p', '--filter', type=str, default='', help='give a filter string. e.g. "job_name=foo" "n=foo" "job_id={1,2-4}" "id={1,2-4}" "user_id=bar" "uid=bar" "node=foo-1" "w=foo-1"', nargs='*')
 
 # iterate
 parser.add_argument('-l', '--loop', type=rate_in_range, default=-1,

--- a/slurm_gres_viz/args.py
+++ b/slurm_gres_viz/args.py
@@ -24,6 +24,8 @@ parser.add_argument('-gm', '--gpu-memory', action='store_true',
 parser.add_argument('-gu', '--gpu-util', action='store_true',
                     help='asd')
 
+parser.add_argument('-p', '--filter', type=str, default='', help='give a filter string. e.g. "job_name=foo" "n=foo" "job_id={1,2-4}" "id={1,2-4}" "user_id=bar" "uid=bar" "node=foo-1" "w=foo-1"')
+
 # iterate
 parser.add_argument('-l', '--loop', type=rate_in_range, default=-1,
                     help='asd')

--- a/slurm_gres_viz/displayer.py
+++ b/slurm_gres_viz/displayer.py
@@ -178,8 +178,7 @@ class DashBoard:  # Upper body
                 for v in values:
                     for nodename, tres_dict in job.tres_dict.items():
                         for gpu_idx in tres_dict['gpus']:
-                            if key == 'user_id':
-                                all_filter_masks[nodename][gpu_idx] = not all_filter_masks[nodename][gpu_idx] or not (v in properties)
+                            all_filter_masks[nodename][gpu_idx] = not all_filter_masks[nodename][gpu_idx] or not (v in properties)
         return all_filter_masks
 
     def get_occupancy_mask(self):
@@ -242,7 +241,7 @@ class Legend:  # Lower body
         if self.filter_dict != {}:
             for key, values in self.filter_dict.items():
                 _df = pd.DataFrame()
-                if key == 'user_id':
+                if key == 'user_id' or key == 'job_name' :
                     for value in values:
                         _df = pd.concat([_df, df[df[key].str.contains(value)]])
                 else:

--- a/slurm_gres_viz/displayer.py
+++ b/slurm_gres_viz/displayer.py
@@ -178,7 +178,8 @@ class DashBoard:  # Upper body
                 for v in values:
                     for nodename, tres_dict in job.tres_dict.items():
                         for gpu_idx in tres_dict['gpus']:
-                            all_filter_masks[nodename][gpu_idx] = not all_filter_masks[nodename][gpu_idx] or not (v in properties)
+                            if key == 'user_id':
+                                all_filter_masks[nodename][gpu_idx] = not all_filter_masks[nodename][gpu_idx] or not (v in properties)
         return all_filter_masks
 
     def get_occupancy_mask(self):
@@ -241,8 +242,12 @@ class Legend:  # Lower body
         if self.filter_dict != {}:
             for key, values in self.filter_dict.items():
                 _df = pd.DataFrame()
-                for value in values:
-                    _df = pd.concat([_df, df[df[key].str.contains(value)]])
+                if key == 'user_id':
+                    for value in values:
+                        _df = pd.concat([_df, df[df[key].str.contains(value)]])
+                else:
+                    for value in values:
+                        _df = pd.concat([_df, df[df[key] == value]])
                 df = pd.merge(df, _df, how='inner',)
         color_legend = df['job_id'].map(lambda jid: colorize('********', get_color_from_idx(int(jid))))  # before the column job_id overwritten
         df['job_id'] = df['job_arr_id'].fillna(df['job_id'])  # firstly with job_arr_id, and overwrite with job_id only for none rows

--- a/slurm_gres_viz/displayer.py
+++ b/slurm_gres_viz/displayer.py
@@ -177,7 +177,10 @@ class DashBoard:  # Upper body
                 _property = getattr(job, name_to_job_object[key])
                 for nodename, tres_dict in job.tres_dict.items():
                     for gpu_idx in tres_dict['gpus']:
-                        all_filter_masks[nodename][gpu_idx] = all_filter_masks[nodename][gpu_idx] and sum([v in _property or v == _property for v in values]) # NAND operation
+                        all_filter_masks[nodename][gpu_idx] = \
+                            all_filter_masks[nodename][gpu_idx] and \
+                            sum([_property == value if sum([c >= '0' and c <= '9' for c in _property])==len(_property) \
+                                else  value in _property for value in values ])
         for nodename, filter_masks in all_filter_masks.items():
             for gpu_idx, is_filtered in enumerate(filter_masks):
                 all_filter_masks[nodename][gpu_idx] = not all_filter_masks[nodename][gpu_idx]

--- a/slurm_gres_viz/main.py
+++ b/slurm_gres_viz/main.py
@@ -21,6 +21,7 @@ def get_display_options():
         'show_gpu_memory': args.full or args.gpu_memory,
         'show_gpu_util': args.full or args.gpu_util,
         'show_only_mine': args.only_mine,
+        'filter_string': args.filter,
     }
     return display_options
 

--- a/slurm_gres_viz/parsers.py
+++ b/slurm_gres_viz/parsers.py
@@ -147,23 +147,22 @@ def filter_string_parser(filter_string:str) -> Dict[str, List[str]]:
     Dict[str:List[str]]
         e.g. {"jobname": ["foo"], "jobid": ["1", "2", "3", "4"], "userid": ["bar"]}
     """
-    available_keys = ['job_id', 'user_id', 'job_name', 'node', 'arrayjobid', 'arraytaskid']
+    available_keys = ['job_id', 'user_id', 'job_name', 'node_name', 'arrayjobid', 'arraytaskid']
     abbreviation_keys = ['id', 'uid', 'n', 'w']
     try:
         filter_dict = {}
-        filter_string = filter_string.split(' ')
-
-        for filter_string in filter_string:
-            key, value = filter_string.split('=')
+        for f_string in filter_string:
+            key, value = f_string.split('=')
             value = value.strip('{}')
             if key in abbreviation_keys:
                 key = available_keys[abbreviation_keys.index(key)]
             if key not in available_keys:
-                raise
+                raise Exception(f'Cannot recognize the filter key: {key}')
             if '-' in value:
-                value = resolve_index_expr(value[1])
-            filter_dict[key] = value
+                value = [str(v) for v in resolve_index_expr(value)]
+            filter_dict[key] = value if isinstance(value, list) else [value]
         return filter_dict
-    except:
+    except Exception as e:
+        print(e)
         print('Filter string is not valid. Please check the format.')
         return {}

--- a/slurm_gres_viz/parsers.py
+++ b/slurm_gres_viz/parsers.py
@@ -133,3 +133,37 @@ def resolve_element_expr(element_expr:str):
 
 def MiB2GiB(MiB:int) -> float:
     return MiB / 1024
+
+def filter_string_parser(filter_string:str) -> Dict[str, List[str]]:
+    """Parse filter string to a list of filter strings
+
+    Parameters
+    ----------
+    filter_string : str
+        e.g. "jobname=foo jobid={1,2-4} userid=bar"
+
+    Returns
+    -------
+    Dict[str:List[str]]
+        e.g. {"jobname": ["foo"], "jobid": ["1", "2", "3", "4"], "userid": ["bar"]}
+    """
+    available_keys = ['job_id', 'user_id', 'job_name', 'node', 'arrayjobid', 'arraytaskid']
+    abbreviation_keys = ['id', 'uid', 'n', 'w']
+    try:
+        filter_dict = {}
+        filter_string = filter_string.split(' ')
+
+        for filter_string in filter_string:
+            key, value = filter_string.split('=')
+            value = value.strip('{}')
+            if key in abbreviation_keys:
+                key = available_keys[abbreviation_keys.index(key)]
+            if key not in available_keys:
+                raise
+            if '-' in value:
+                value = resolve_index_expr(value[1])
+            filter_dict[key] = value
+        return filter_dict
+    except:
+        print('Filter string is not valid. Please check the format.')
+        return {}

--- a/slurm_gres_viz/visualizer.py
+++ b/slurm_gres_viz/visualizer.py
@@ -16,7 +16,7 @@ class SlurmTresVisualizer:
         test_mode:bool=False,
 
         show_index:bool=False, show_gpu_memory:bool=False, show_gpu_util:bool=False,
-        show_only_mine:bool=False
+        show_only_mine:bool=False, filter_string:str=''
     ):
         self.node_strings = node_strings
         self.job_strings = job_strings
@@ -27,6 +27,7 @@ class SlurmTresVisualizer:
         self.show_gpu_memory = show_gpu_memory
         self.show_gpu_util = show_gpu_util
         self.show_only_mine = show_only_mine
+        self.filter_string = filter_string
 
         self.nodes, self.jobs = self.get_infos()
 
@@ -79,7 +80,8 @@ class SlurmTresVisualizer:
             show_index=self.show_index,
             show_gpu_memory=self.show_gpu_memory,
             show_gpu_util=self.show_gpu_util,
-            show_only_mine=self.show_only_mine
+            show_only_mine=self.show_only_mine,
+            filter_string=self.filter_string
         )
         displayer.show()
 

--- a/slurm_gres_viz/visualizer.py
+++ b/slurm_gres_viz/visualizer.py
@@ -1,5 +1,6 @@
 import re
 from typing import List, Tuple, Dict
+from parsers import filter_string_parser
 from multiprocessing.pool import ThreadPool
 
 if __name__.startswith('slurm_gres_viz'):  # for test
@@ -81,7 +82,7 @@ class SlurmTresVisualizer:
             show_gpu_memory=self.show_gpu_memory,
             show_gpu_util=self.show_gpu_util,
             show_only_mine=self.show_only_mine,
-            filter_string=self.filter_string
+            filter_dict=filter_string_parser(self.filter_string)
         )
         displayer.show()
 


### PR DESCRIPTION
Enable the string filter to select jobs by job_id, node_name, and user_id. 
Also, multiple filter key is supported, by nagrs=*, 
it is possible to select "My job on certain node" or "from xxx to yyy of job id select my jobs".
For convenience, 'name' caused all jobs containing that name to be displayed. 

It is tested on the Trinity GPU server and I fixed most of the Search results which were unintended, but there may still be some minor issues, feel free to contact me to handle the problem.